### PR TITLE
Checks to reduce the incidence of DB entry errors during cell culture experiments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 cloneid_1.1.0.tar.gz filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
+cloneid_*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/cloneid_1.2.0.tar.gz
+++ b/cloneid_1.2.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5bf1c6ac45ea3d4b45c7b32760a0272074c6996b9a0fb2f6bc72c3db5f1c9542
-size 178333500

--- a/cloneid_1.2.1.tar.gz
+++ b/cloneid_1.2.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff7419f3e89e6fbd15374f13cdf5834262270816b5fb3fe696193664574c8d84
+size 178334921

--- a/src/main/java/cloneid/Manager.java
+++ b/src/main/java/cloneid/Manager.java
@@ -213,13 +213,13 @@ public final class Manager {
 //			p.save2DB();
 //			profile(3456, Perspectives.GenomePerspective);
 //			Perspective p2 = new GenomePerspective(new File("/Users/noemi/Projects/PMO/MeasuringGIperClone/data/GastricCancerCLs/scDNAseq/E07_180831_clones/HGC-27.sps.cbs"), "CN_Estimate");
-			Perspective p2 = new TranscriptomePerspective(new File("~/Downloads/testViewPerspective/TranscriptomePerspective/SNU-16.sps.cbs"), "CN_Estimate");
+//			Perspective p2 = new TranscriptomePerspective(new File("~/Downloads/testViewPerspective/TranscriptomePerspective/SNU-16.sps.cbs"), "CN_Estimate");
 //			System.out.println(p2.getChildrensSizes());
 			//			p2.save2DB();
 //			display(253823, Perspectives.MorphologyPerspective);
 //			profiles(257274, Perspectives.MorphologyPerspective,false);
 //			display("SNU-601_A4_seedT5", Perspectives.MorphologyPerspective);
-			profiles(134018, Perspectives.GenomePerspective, false);
+//			profiles(134018, Perspectives.GenomePerspective, false);
 //			TranscriptomePerspective tmp = new TranscriptomePerspective(new File("/Users/4470246/Projects/PMO/MeasuringGIperClone/data/GastricCancerCLs/scRNAseq/C07_190610_LIAYSON//SNU-16_3.sps.cbs"), "CN_Estimate");
 //			TranscriptomePerspective tmp = new TranscriptomePerspective(new File("/Users/4470246/Projects/PMO/MeasuringGIperClone/data/GastricCancerCLs/scRNAseq/C07_190610_LIAYSON//SNU-16_3.0.1914997.sps.cbs"), "Clone_0.191499695181847");
 //tmp.save2DB();

--- a/src/main/java/database/CLONEID.java
+++ b/src/main/java/database/CLONEID.java
@@ -70,10 +70,10 @@ public final class CLONEID {
 		if(!cloneClass.contains(tableName)){
 			tableName="Perspective"; //@TODO: improve table choice
 		}
-		//@TODO: remove after solving speed issues for table Perspective
-		if(cloneClass.contains("MorphologyPerspective")){
-			tableName="MorphologyPerspective"; 
-		}
+		////@TODO: remove after solving speed issues for table Perspective
+		//if(cloneClass.contains("MorphologyPerspective")){
+		//	tableName="MorphologyPerspective"; 
+		//}
 		return(tableName);
 	}
 


### PR DESCRIPTION
1) If an error is encountered while calling seed or harvest , then user will have to acknowledge the error first before further processing takes place. 2) User will be warned if the assignment between id and passaged_from_id1 appears to be incorrect. As in 1) they will have to acknowledge the warning (either confirming the assignment is incorrect or proceeding despite the warning). 3) Passaging table will automatically record who made an entry and who last modified it.